### PR TITLE
- Added optional QT_BINPATH argument for setting where the Qt bin direct...

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To inform scons where to find the Fabric Core includes as well as the thirdparty
 * BOOST_DIR: Should point to the boost root folder (containing boost/ (includes) and lib/ for the static libraries).
 * QT_INCLUDE_DIR: The include folder of the Qt installation.
 * QT_LIB_DIR: The library folder of the Qt installation.
+* QT_BINPATH: Optional directory to the bin folder of the Qt installation. 
 
 The temporary files will be built into the *.build* folder, while the structured output files will be placed in the *.stage* folder.
 

--- a/SConscript
+++ b/SConscript
@@ -14,6 +14,7 @@ Import(
   'FABRIC_BUILD_TYPE',
   'QT_INCLUDE_DIR',
   'QT_LIB_DIR',
+  'QT_BINPATH',
   'sharedCapiFlags',
   'spliceFlags'
   )
@@ -26,6 +27,10 @@ if FABRIC_BUILD_OS == 'Darwin':
 
 # create the build environment
 env = Environment(MSVC_VERSION='10.0', tools=['default','qt'], QTDIR=qtDir, QT_LIB='', ENV=parentEnv['ENV'])
+
+if QT_BINPATH:
+  env.Replace(QT_BINPATH=QT_BINPATH)
+
 if FABRIC_BUILD_OS == 'Linux':
   env.Replace(QT_MOC = '$QT_BINPATH/moc-qt4')
   if FABRIC_BUILD_DIST == 'CentOS':

--- a/SConstruct
+++ b/SConstruct
@@ -67,10 +67,12 @@ else:
     'FABRIC_BUILD_TYPE': os.environ['FABRIC_BUILD_TYPE'],
     'FABRIC_BUILD_OS': os.environ['FABRIC_BUILD_OS'],
     'FABRIC_BUILD_ARCH': os.environ['FABRIC_BUILD_ARCH'],
+    'FABRIC_BUILD_DIST': os.environ['FABRIC_BUILD_DIST'],
     'STAGE_DIR': spliceEnv.Dir('.stage').Dir('SpliceIntegrations').Dir('FabricSpliceStandalone'+os.environ['FABRIC_SPLICE_VERSION']),
     'BOOST_DIR': os.environ['BOOST_DIR'],
     'QT_INCLUDE_DIR': os.environ['QT_INCLUDE_DIR'],
-    'QT_LIB_DIR': os.environ['QT_LIB_DIR']
+    'QT_LIB_DIR': os.environ['QT_LIB_DIR'],
+    'QT_BINPATH': os.environ.get('QT_BINPATH', None)
   },
   variant_dir = spliceEnv.Dir('.build')
 )


### PR DESCRIPTION
Added optional QT_BINPATH argument for setting where the Qt bin directory is. Useful for finding the moc tool needed during compilation.

Also fixed issue with FABRIC_BUILD_DIST not being exported from SConstruct file, which caused a failure building on OSX. 